### PR TITLE
Fix: Handle error when patch dir is empty

### DIFF
--- a/target-scripts/extract-kubespray.sh
+++ b/target-scripts/extract-kubespray.sh
@@ -23,7 +23,9 @@ tar xvzf $KUBESPRAY_TARBALL || exit 1
 sleep 1 # avoid annoying patch error in shared folders.
 if [ -d $CURRENT_DIR/patches/${KUBESPRAY_VERSION} ]; then
     for patch in $CURRENT_DIR/patches/${KUBESPRAY_VERSION}/*.patch; do
-        echo "===> Apply patch: $patch"
-        (cd $DIR && patch -p1 < $patch)
+        if [[ -f "${patch}" ]]; then
+          echo "===> Apply patch: $patch"
+          (cd $DIR && patch -p1 < $patch)
+        fi
     done
 fi


### PR DESCRIPTION
When the patch dir is empty the #PATCH_DIR/*.patch is not expanded and handled as a file name leading to "No such file or directory" error