### PR TITLE
fix: lack of  before calling scripts/select-python.sh

### DIFF
--- a/pypi-mirror.sh
+++ b/pypi-mirror.sh
@@ -8,6 +8,7 @@ if [ ! -e $KUBESPRAY_DIR ]; then
     exit 1
 fi
 
+source /etc/os-release
 source ./scripts/select-python.sh
 
 VENV_DIR=${VENV_DIR:-~/.venv/default}


### PR DESCRIPTION
${VERSION_ID} is missing in pypi-mirror.sh before calling to scripts/select-python.sh, which makes it always takes python 3.8 as a default one in all release of RHEL.